### PR TITLE
Allow custom injected address ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "material-ui-address-input",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A customisable address input component for Material-UI.",
   "main": "lib/AddressInput.js",
   "scripts": {

--- a/src/AddressInput.js
+++ b/src/AddressInput.js
@@ -204,8 +204,8 @@ class AddressInput extends Component {
               {
                 this.props.allAddresses.map((address, index) => (
                   this.props.native
-                    ? <option key={index} value={index}>{this.stringifyAddress(address)}</option>
-                    : <MenuItem key={index} value={index}>{this.stringifyAddress(address)}</MenuItem>
+                    ? <option key={index} value={address.id || index}>{this.stringifyAddress(address)}</option>
+                    : <MenuItem key={index} value={address.id || index}>{this.stringifyAddress(address)}</MenuItem>
                 ))
               }
               {this.props.native


### PR DESCRIPTION
In the last PR a change was omitted that allows the address object to have a custom `id` injected into it that becomes the value passed to the `onChange` function when that address is changed. This custom `id` can be either a number or a string.

This change is backwards compatible, and if you do not inject your own custom `id` then the index in the list of addresses will be used as the value.