### PR TITLE
Changed helperText proptype from string to node

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ export default ControlledAddressInput
 | `disabled` | `bool` | `false` | If `true`, the label, input and helper text should be displayed in a disabled state. |
 | `displayCountry` | `bool` | `true` | Whether the address selector should allow users to choose their country. Often disabled if your application typically has users from a single country. |
 | `error` | `bool` | | If `true` the address dropdown will be in an error state and appear red. |
-| `helperText` | `string` | | Helper text to display below the address selector. |
+| `helperText` | `node` | | The helper text content |
 | `id` | `string` | `'address'` | The `id` to be passed to the select element. |
 | `label` | `string` | `'Address'` | The label to be shown on the address picker component. |
 | `margin` | `enum: 'none' | 'dense' | 'normal'` | `'none'` | If `dense` or `normal`, will adjust vertical spacing of this component. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "material-ui-address-input",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A customisable address input component for Material-UI.",
   "main": "lib/AddressInput.js",
   "scripts": {

--- a/src/AddressInput.js
+++ b/src/AddressInput.js
@@ -400,7 +400,7 @@ AddressInput.propTypes = {
   disabled: PropTypes.bool,
   displayCountry: PropTypes.bool,
   error: PropTypes.bool,
-  helperText: PropTypes.string,
+  helperText: PropTypes.node,
   id: PropTypes.string,
   label: PropTypes.string,
   margin: PropTypes.oneOf(['none', 'dense', 'normal']),


### PR DESCRIPTION
The `helperText` PropType was always `string` which is more limiting than material-ui allows. This small update changes the `helperText` PropType to `node` (in line with its namesake PropType on Select elements in material-ui).