### PR TITLE
Add empty option to fit with material-ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "material-ui-address-input",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A customisable address input component for Material-UI.",
   "main": "lib/AddressInput.js",
   "scripts": {

--- a/src/AddressInput.js
+++ b/src/AddressInput.js
@@ -199,8 +199,9 @@ class AddressInput extends Component {
               onChange={this.handleChangeAddress}
               value={this.props.value}
             >
-              {this.props.allAddresses.length === 0 && this.props.native
-                ? <option value='' /> : null
+              {this.props.native
+                ? <option value='' />
+                : <MenuItem value=''>Choose an address...</MenuItem>
               }
               {
                 this.props.allAddresses.map((address, index) => (


### PR DESCRIPTION
This patch adds an empty option that allows the component to fit in better with libs such as redux-form that check if the component has an empty value `''`.